### PR TITLE
Close logger when stopping dht

### DIFF
--- a/core/logging_conf.py
+++ b/core/logging_conf.py
@@ -17,8 +17,8 @@ FORMAT = '%(asctime)s %(levelname)s %(filename)s:%(lineno)s - %(funcName)s()\n\
 #                    stream=devnullstream)
 
 
-LOG_SIZE_LIMIT_NORMAL = 10 * 2**20 # 10 MB
-LOG_SIZE_LIMIT_DEBUG = 2**30 # 1 GB
+LOG_SIZE_LIMIT_NORMAL = 10 * 2 ** 20  # 10 MB
+LOG_SIZE_LIMIT_DEBUG = 2 ** 30  # 1 GB
 
 
 def testing_setup(module_name):
@@ -30,7 +30,7 @@ def testing_setup(module_name):
     logger.setLevel(logging.DEBUG)
     filename = ''.join((str(module_name), '.log'))
     logger_file = os.path.join('test_logs', filename)
-    
+
     logger_conf = logging.FileHandler(logger_file, 'w')
     logger_conf.setLevel(logging.DEBUG)
     logger_conf.setFormatter(logging.Formatter(FORMAT))
@@ -51,4 +51,12 @@ def setup(logs_path, logs_level):
     logger_conf.setFormatter(logging.Formatter(FORMAT))
     logger.addHandler(logger_conf)
 
-
+def close():
+    logger = logging.getLogger('dht')
+    for i in list(logger.handlers):
+        logger.removeHandler(i)
+        try:
+            i.flush()
+            i.close()
+        except:
+            pass

--- a/core/pymdht.py
+++ b/core/pymdht.py
@@ -90,6 +90,8 @@ class Pymdht:
         if self.swift_tracker_thread:
             self.swift_tracker_thread.stop()
 
+        logging_conf.close()
+
     def get_peers(self, lookup_id, info_hash, callback_f,
                   bt_port=0, use_cache=False):
         """ Start a get peers lookup. Return a Lookup object.


### PR DESCRIPTION
The dht did not close the logger, which was causing problems while unittesting on windows as it had a filelock on the pymdht.log file.
