### PR TITLE
Fix a string format problem

### DIFF
--- a/plugins/lookup_a4.py
+++ b/plugins/lookup_a4.py
@@ -252,7 +252,7 @@ class GetPeersLookup(object):
                 lookup_done)
     
     def on_error_received(self, error_msg, node_addr):
-        logger.debug('Got error from node addr: %r' % node_addr)
+        logger.debug('Got error from node addr: %s:%s', node_addr[0], node_addr[1])
         self._num_parallel_queries -= 1
         self.num_errors += 1
 


### PR DESCRIPTION
Got the following back trace. Also see (https://github.com/Tribler/tribler/issues/1102)

```
CRITICAL 1419946607.11     minitwisted:105   MINITWISTED CRASHED
ERROR   1419946607.12     minitwisted:106   MINITWISTED CRASHED
Traceback (most recent call last):
  File "/home/lfei/workspace/tud/p2p/tribler/Tribler/Core/DecentralizedTracking/pymdht/core/minitwisted.py", line 103, in run2
    self.run_one_step()
  File "/home/lfei/workspace/tud/p2p/tribler/Tribler/Core/DecentralizedTracking/pymdht/core/minitwisted.py", line 179, in run_one_step
    datagram_received)
  File "/home/lfei/workspace/tud/p2p/tribler/Tribler/Core/DecentralizedTracking/pymdht/core/controller.py", line 291, in on_datagram_received
    ) = related_query.lookup_obj.on_error_received(msg, addr)
  File "/home/lfei/workspace/tud/p2p/tribler/Tribler/Core/DecentralizedTracking/pymdht/plugins/lookup_a4.py", line 255, in on_error_received
    logger.debug('Got error from node addr: %r' % node_addr)
TypeError: not all arguments converted during string formatting
MINITWISTED CRASHED (see logs)
```
